### PR TITLE
Usar python3.7 para rodar o script post_to_world

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     apt:
         packages:
             - python3
+            - python3.7
             - python3-pip
             - python3-setuptools
             - sshpass

--- a/_scripts/check_new_posts.sh
+++ b/_scripts/check_new_posts.sh
@@ -8,5 +8,5 @@ fi
 
 # Getting the name of all files in the directory `_posts/` that were added in the last commit
 for f in `git diff HEAD^ --name-only --diff-filter=A --relative=_posts`; do
-	python3 ./_scripts/post_to_world.py $f $MARATONIME_HELPER_TOKEN $MARATONIME_PAGE_TOKEN
+	python3.7 ./_scripts/post_to_world.py $f $MARATONIME_HELPER_TOKEN $MARATONIME_PAGE_TOKEN
 done

--- a/_scripts/post_to_world.py
+++ b/_scripts/post_to_world.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.7
 import sys
 
 # Parameters


### PR DESCRIPTION
Ocorreu um problema com o build e ele pode estar relacionado com a
versão do python instalada no sistema que roda o site (3.5).