### PR TITLE
Adiciona importlib-resources como dependência

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
     apt:
         packages:
             - python3
-            - python3.7
             - python3-pip
             - python3-setuptools
             - sshpass

--- a/_scripts/check_new_posts.sh
+++ b/_scripts/check_new_posts.sh
@@ -8,5 +8,5 @@ fi
 
 # Getting the name of all files in the directory `_posts/` that were added in the last commit
 for f in `git diff HEAD^ --name-only --diff-filter=A --relative=_posts`; do
-	python3.7 ./_scripts/post_to_world.py $f $MARATONIME_HELPER_TOKEN $MARATONIME_PAGE_TOKEN
+	python3 ./_scripts/post_to_world.py $f $MARATONIME_HELPER_TOKEN $MARATONIME_PAGE_TOKEN
 done

--- a/_scripts/post_to_world.py
+++ b/_scripts/post_to_world.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 import sys
 
 # Parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML>=3.12
 requests>=2.9.1
+importlib-resources>=5.7.1


### PR DESCRIPTION
A instalação do Python 3.7 não funcionou. Para resolver o erro da
build, será incluída a importlib-resources como dependência.
Ela tem como objetivo oferecer o pacote importlib.resources para versões
mais antigas de Python.