### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+_site/
+site.tar.gz


### PR DESCRIPTION
Without _site & site.tar.gz in the .dockerignore, building the project repeatedly recursively accumulates files